### PR TITLE
Dismiss out of range messages

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -20,6 +20,9 @@ is_pr_wip = github.pr_title.include? "[WIP]"
 
 is_pr_big = git.lines_of_code > max_pr_length
 
+# Do not show out of range issues, not caused by the current PR
+github.dismiss_out_of_range_messages
+
 # Throw errors
 fail("Only hotfix and release can point to master.") if !can_be_merged_to_master and github.branch_for_base == "master"
 
@@ -57,6 +60,3 @@ if File.file?(build_report_file) then
   xcode_summary.inline_mode = true
   xcode_summary.report build_report_file
 end
-
-# Do not show out of range issues, not caused by the current PR
-github.dismiss_out_of_range_messages

--- a/Dangerfile
+++ b/Dangerfile
@@ -58,4 +58,5 @@ if File.file?(build_report_file) then
   xcode_summary.report build_report_file
 end
 
-
+# Do not show out of range issues, not caused by the current PR
+github.dismiss_out_of_range_messages

--- a/thefuntasty_danger.gemspec
+++ b/thefuntasty_danger.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "thefuntasty_danger"
-  spec.version     = "0.1.2"
+  spec.version     = "0.1.3"
   spec.authors     = ["Matěj Kašpar Jirásek"]
   spec.email       = ["matej.jirasek@thefuntasty.com"]
 


### PR DESCRIPTION
On CarPics and Tipsport projects I learnt that it's not good when Danger shows out of range issues in the PR – from the outside of the change range. These are not caused by the current PR, are irrelevant to the PR and confuses the author.