### PR TITLE
Dependency documentation check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,6 +3,7 @@ jira_link = "https://thefuntasty.atlassian.net/browse/"
 max_pr_length = 500
 swiftlint_binary_path = './Pods/SwiftLint/swiftlint'
 build_report_file = 'build/reports/errors.json'
+dependency_configuration_files = ['Package.swift', 'Package.resolved', 'Podfile', 'Cartfile']
 
 # Regular expressions for PR title and branch
 pr_title_pattern = /^([A-Z]{2,}-\d+)\s\w{2,}/
@@ -61,4 +62,14 @@ if File.file?(build_report_file) then
   xcode_summary.ignored_files = '**/Pods/**'
   xcode_summary.inline_mode = true
   xcode_summary.report build_report_file
+end
+
+# Warn about documenting dependency changes
+modified_dependencies = git.modified_files.any? { |path|
+  dependency_configuration_files.any? { |config|
+    path.end_with? config
+  }
+}
+if !git.modified_files.include?("README.md") and modified_dependencies then
+  warn("README.md should be updated when dependencies are changed.")
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thefuntasty_danger (0.7.0)
+    thefuntasty_danger (0.8.0)
       danger (~> 8)
       danger-commit_lint (~> 0)
       danger-swiftlint (~> 0)
@@ -20,7 +20,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (8.2.3)
+    danger (8.4.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -37,20 +37,34 @@ GEM
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-swiftlint (0.24.5)
+    danger-swiftlint (0.29.4)
       danger
       rake (> 10)
       thor (~> 0.19)
-    danger-xcode_summary (0.5.2)
+    danger-xcode_summary (0.5.3)
       danger-plugin-api (~> 1.0)
-    faraday (1.3.0)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
+    faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    git (1.8.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    git (1.9.1)
       rchardet (~> 1.8)
     kramdown (2.3.1)
       rexml
@@ -59,22 +73,22 @@ GEM
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (4.0.6)
-    rake (13.0.3)
+    rake (13.0.6)
     rchardet (1.8.0)
     rexml (3.2.5)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    terminal-table (3.0.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (0.20.3)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -83,4 +97,4 @@ DEPENDENCIES
   thefuntasty_danger!
 
 BUNDLED WITH
-   2.1.4
+   2.2.29

--- a/thefuntasty_danger.gemspec
+++ b/thefuntasty_danger.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "thefuntasty_danger"
-  spec.version     = "0.7.0"
+  spec.version     = "0.8.0"
   spec.authors     = ["Matěj Kašpar Jirásek"]
   spec.email       = ["matej.jirasek@futured.app"]
 


### PR DESCRIPTION
Add warning about updating `README.md` when dependency configuration files are changed.

@skywall @SumeraMartin: If you want to use the check on Android too, please add relevant files. 

Closes #21.