### PR TITLE
Fix not found xcresult file

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -58,7 +58,7 @@ end
 
 # Send iOS build results if possible
 xcresult_file = Dir["fastlane/test_output/*.xcresult"].first
-if File.exist? xcresult_file then
+if !xcresult_file.nil? then
   xcode_summary.ignored_files = 'Pods/**'
   xcode_summary.inline_mode = true
   xcode_summary.report xcresult_file

--- a/thefuntasty_danger.gemspec
+++ b/thefuntasty_danger.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "thefuntasty_danger"
-  spec.version     = "0.8.0"
+  spec.version     = "0.9.0"
   spec.authors     = ["Matěj Kašpar Jirásek"]
   spec.email       = ["matej.jirasek@futured.app"]
 


### PR DESCRIPTION
Fixes Danger on non-iOS platforms which do not generate xcresult file.