### PR TITLE
Remove swiftlint

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,7 +1,6 @@
 # Configuration
 jira_link = "https://thefuntasty.atlassian.net/browse/"
 max_pr_length = 500
-swiftlint_binary_path = './Pods/SwiftLint/swiftlint'
 dependency_configuration_files = ['Package.swift', 'Package.resolved', 'Podfile', 'Cartfile']
 
 # Regular expressions for PR title and branch
@@ -47,14 +46,6 @@ end
 
 # Check commit messages
 commit_lint.check warn: :all, disable: [:subject_length]
-
-# Run Swiftlint if possible.
-# There is no easier way to check, if danger-swiftlint is installed
-if `gem list -i danger-swiftlint`.strip == "true" then
-  swiftlint.binary_path = swiftlint_binary_path if File.file?(swiftlint_binary_path)
-  swiftlint.max_num_violations = 20
-  swiftlint.lint_files inline_mode: true
-end
 
 # Send iOS build results if possible
 xcresult_file = Dir["fastlane/test_output/*.xcresult"].first

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ These are the rules we use for checking our pull requests by Danger optimized fo
 - Should not be over 500 lines.
 - Commit names should start with a large letter and should not be too long.
 - iOS specific:
-  - Swiftlint should not produce any warnings.
   - Xcode build should not produce any warnings.
 
 Examples of pretty branch names:

--- a/thefuntasty_danger.gemspec
+++ b/thefuntasty_danger.gemspec
@@ -1,9 +1,9 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "thefuntasty_danger"
-  spec.version     = "0.9.1"
+  spec.version     = "0.9.2"
   spec.authors     = ["Matěj Kašpar Jirásek"]
-  spec.email       = ["matej.jirasek@futured.app"]
+  spec.email       = ["ops@futured.app"]
 
   spec.summary     = "The Danger rules we use at Futured"
   spec.description = "Danger configuration used at Futured, currently mainly for iOS development"
@@ -15,5 +15,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'danger', '~> 9'
   spec.add_runtime_dependency 'danger-commit_lint', '~> 0'
   spec.add_runtime_dependency 'danger-xcode_summary', '~> 1'
-  spec.add_runtime_dependency 'danger-swiftlint', '~> 0'
 end


### PR DESCRIPTION
Odebrání swift lint z dangeru - používáme deprecated knihovnu, přepsání na aktuální řešení není na pořadu dne