### PR TITLE
 Failing xcresult on XCodes 26

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -66,7 +66,11 @@ xcresult_file = Dir["fastlane/test_output/*.xcresult"].first
 if !xcresult_file.nil? then
   xcode_summary.ignored_files = 'Pods/**'
   xcode_summary.inline_mode = true
-  xcode_summary.report xcresult_file
+  begin
+    xcode_summary.report xcresult_file if File.exist?(xcresult_file)
+  rescue => e
+    puts "⚠️  Skipping xcresult report: #{e.message}"
+  end
 end
 
 # Warn about documenting dependency changes

--- a/thefuntasty_danger.gemspec
+++ b/thefuntasty_danger.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "thefuntasty_danger"
-  spec.version     = "0.9.3"
+  spec.version     = "0.9.5"
   spec.authors     = ["Matěj Kašpar Jirásek"]
   spec.email       = ["ops@futured.app"]
 


### PR DESCRIPTION
### Summary

This PR introduces robust error handling for `xcresult` reporting in the `Dangerfile` and updates the gem version. It prevents potential crashes during report generation and ensures the report is only attempted if the `xcresult` file exists.

### Key Features

*   **Improved `xcresult` reporting:** Added a `begin...rescue` block to gracefully handle errors during `xcode_summary.report` execution, logging a warning message instead of crashing.
*   **Conditional `xcresult` reporting:** The `xcode_summary.report` is now only called if `File.exist?(xcresult_file)` returns true, preventing errors when the file is missing.
*   **Gem version update:** Updated `thefuntasty_danger` gem version from `0.9.3` to `0.9.5`.
